### PR TITLE
Fix deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "authors": [
         {
             "name": "Chris Boulton",
-            "email": "@chrisboulton"
+            "email": "chris@chrisboulton.no-email"
         }
     ],
     "autoload": {
@@ -14,6 +14,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.5"
+        "phpunit/phpunit": "~8"
     }
 }

--- a/lib/Diff/SequenceMatcher.php
+++ b/lib/Diff/SequenceMatcher.php
@@ -76,6 +76,21 @@ class Diff_SequenceMatcher
 	);
 
 	/**
+	 * @var array|null
+	 */
+	private $matchingBlocks;
+
+	/**
+	 * @var array|null
+	 */
+	private $opCodes;
+
+	/**
+	 * @var array|null
+	 */
+	private $fullBCount;
+
+	/**
 	 * The constructor. With the sequences being passed, they'll be set for the
 	 * sequence matcher and it will perform a basic cleanup & calculate junk
 	 * elements.
@@ -84,7 +99,7 @@ class Diff_SequenceMatcher
 	 * @param string|array $b A string or array containing the lines to compare.
 	 * @param string|array $junkCallback Either an array or string that references a callback function (if there is one) to determine 'junk' characters.
 	 */
-	public function __construct($a, $b, $junkCallback=null, $options)
+	public function __construct($a, $b, $junkCallback, $options)
 	{
 		$this->a = null;
 		$this->b = null;
@@ -349,8 +364,8 @@ class Diff_SequenceMatcher
 			return $this->matchingBlocks;
 		}
 
-		$aLength = count($this->a);
-		$bLength = count($this->b);
+		$aLength = count($this->a ?? []);
+		$bLength = count($this->b ?? []);
 
 		$queue = array(
 			array(

--- a/tests/Diff/Renderer/Html/ArrayTest.php
+++ b/tests/Diff/Renderer/Html/ArrayTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Diff\Renderer\Html;
 
-class ArrayTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ArrayTest extends TestCase
 {
     public function testRenderSimpleDelete()
     {


### PR DESCRIPTION
### Fixes
Fixes deprecation warnings:
```
PHP Deprecated:  Diff_SequenceMatcher::__construct(): Optional parameter $junkCallback declared before required parameter $options is implicitly treated as a required parameter in php-diff/lib/Diff/SequenceMatcher.php on line 87
PHP Deprecated:  Creation of dynamic property Diff_SequenceMatcher::$matchingBlocks is deprecated in php-diff/lib/Diff/SequenceMatcher.php on line 129
PHP Deprecated:  Creation of dynamic property Diff_SequenceMatcher::$opCodes is deprecated in php-diff/lib/Diff/SequenceMatcher.php on line 130
PHP Deprecated:  Creation of dynamic property Diff_SequenceMatcher::$matchingBlocks is deprecated in php-diff/lib/Diff/SequenceMatcher.php on line 129
PHP Deprecated:  Creation of dynamic property Diff_SequenceMatcher::$opCodes is deprecated in php-diff/lib/Diff/SequenceMatcher.php on line 130
PHP Deprecated:  Creation of dynamic property Diff_SequenceMatcher::$fullBCount is deprecated in php-diff/lib/Diff/SequenceMatcher.php on line 151
```

Fixes error:
```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given

php-diff/lib/Diff/SequenceMatcher.php:353
php-diff/lib/Diff/SequenceMatcher.php:467
php-diff/lib/Diff/SequenceMatcher.php:523
php-diff/lib/Diff.php:176
php-diff/lib/Diff/Renderer/Html/Array.php:70
php-diff/tests/Diff/Renderer/Html/ArrayTest.php:17
```

Fixes composer email address which caused composer install to fail:
```
$ composer install

In Factory.php line 317:

  "./composer.json" does not match the expected JSON schema:
   - authors[0].email : Invalid email
```

Upgrades PHPUnit so a version that can be installed on current versions of PHP

### Why
To support newer versions of PHP without producing a lot of warnings